### PR TITLE
Improve service configuration

### DIFF
--- a/src/services/DataImportService.ts
+++ b/src/services/DataImportService.ts
@@ -119,4 +119,4 @@ class DataImportService {
   }
 }
 
-export const dataImportService = DataImportService.getInstance() 
+export const dataImportService = DataImportService.getInstance();

--- a/src/services/DataProcessingService.ts
+++ b/src/services/DataProcessingService.ts
@@ -1,19 +1,19 @@
-import Papa from 'papaparse'
-import * as XLSX from 'xlsx'
-import { format } from 'date-fns'
-import type { ProcessedDataPoint, DatasetConfig } from '@/types'
+import Papa from 'papaparse';
+import * as XLSX from 'xlsx';
+import { format } from 'date-fns';
+import type { ProcessedDataPoint, DatasetConfig } from '@/types';
+import { DEFAULT_DATASET_CONFIGS, type DatasetType } from './datasetConfigs';
 
 export interface RawDataRow {
   [key: string]: any
 }
 
 class DataProcessingService {
-  private static instance: DataProcessingService
-  private datasetConfigs: Map<string, DatasetConfig>
+  private static instance: DataProcessingService;
+  private datasetConfigs: Map<DatasetType, DatasetConfig>;
 
   private constructor() {
-    this.datasetConfigs = new Map()
-    this.initializeDatasetConfigs()
+    this.datasetConfigs = new Map(Object.entries(DEFAULT_DATASET_CONFIGS) as [DatasetType, DatasetConfig][]);
   }
 
   static getInstance(): DataProcessingService {
@@ -23,65 +23,8 @@ class DataProcessingService {
     return DataProcessingService.instance
   }
 
-  private initializeDatasetConfigs() {
-    // Configuração para dados da EPE
-    this.datasetConfigs.set('epe', {
-      name: 'Dados EPE',
-      description: 'Dados de consumo energético da EPE',
-      source: 'EPE',
-      format: 'csv',
-      columns: {
-        timestamp: 'data',
-        value: 'consumo',
-        category: 'classe',
-        region: 'regiao'
-      }
-    })
 
-    // Configuração para dados da ANEEL
-    this.datasetConfigs.set('aneel', {
-      name: 'Dados ANEEL',
-      description: 'Dados de consumo energético da ANEEL',
-      source: 'ANEEL',
-      format: 'csv',
-      columns: {
-        timestamp: 'data',
-        value: 'consumo',
-        category: 'tipo_consumidor',
-        region: 'estado'
-      }
-    })
-
-    // Configuração para dados meteorológicos
-    this.datasetConfigs.set('meteo', {
-      name: 'Dados Meteorológicos',
-      description: 'Dados meteorológicos por região',
-      source: 'INMET',
-      format: 'csv',
-      columns: {
-        timestamp: 'data',
-        value: 'temperatura',
-        category: 'tipo_medicao',
-        region: 'estacao'
-      }
-    })
-
-    // Configuração para dados do censo
-    this.datasetConfigs.set('censo', {
-      name: 'Dados do Censo',
-      description: 'Dados demográficos do IBGE',
-      source: 'IBGE',
-      format: 'xlsx',
-      columns: {
-        timestamp: 'ano',
-        value: 'populacao',
-        category: 'faixa_etaria',
-        region: 'municipio'
-      }
-    })
-  }
-
-  async processFile(file: File, datasetType: string): Promise<ProcessedDataPoint[]> {
+  async processFile(file: File, datasetType: DatasetType): Promise<ProcessedDataPoint[]> {
     const config = this.datasetConfigs.get(datasetType)
     if (!config) {
       throw new Error(`Tipo de dataset não configurado: ${datasetType}`)
@@ -207,4 +150,4 @@ class DataProcessingService {
   }
 }
 
-export const dataProcessingService = DataProcessingService.getInstance() 
+export const dataProcessingService = DataProcessingService.getInstance();

--- a/src/services/datasetConfigs.ts
+++ b/src/services/datasetConfigs.ts
@@ -1,0 +1,56 @@
+import type { DatasetConfig } from '@/types';
+
+export type DatasetType = 'epe' | 'aneel' | 'meteo' | 'censo';
+
+export const DEFAULT_DATASET_CONFIGS: Record<DatasetType, DatasetConfig> = {
+  epe: {
+    name: 'Dados EPE',
+    description: 'Dados de consumo energético da EPE',
+    source: 'EPE',
+    format: 'csv',
+    columns: {
+      timestamp: 'data',
+      value: 'consumo',
+      category: 'classe',
+      region: 'regiao'
+    }
+  },
+  aneel: {
+    name: 'Dados ANEEL',
+    description: 'Dados de consumo energético da ANEEL',
+    source: 'ANEEL',
+    format: 'csv',
+    columns: {
+      timestamp: 'data',
+      value: 'consumo',
+      category: 'tipo_consumidor',
+      region: 'estado'
+    }
+  },
+  meteo: {
+    name: 'Dados Meteorológicos',
+    description: 'Dados meteorológicos por região',
+    source: 'INMET',
+    format: 'csv',
+    columns: {
+      timestamp: 'data',
+      value: 'temperatura',
+      category: 'tipo_medicao',
+      region: 'estacao'
+    }
+  },
+  censo: {
+    name: 'Dados do Censo',
+    description: 'Dados demográficos do IBGE',
+    source: 'IBGE',
+    format: 'xlsx',
+    columns: {
+      timestamp: 'ano',
+      value: 'populacao',
+      category: 'faixa_etaria',
+      region: 'municipio'
+    }
+  }
+};
+
+

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,8 +1,9 @@
-export { authService } from './AuthService'
-export { dataAnalysisService } from './DataAnalysisService'
-export { dataProcessingService } from './DataProcessingService'
-export { dataImportService } from './DataImportService'
-export { energyService } from './EnergyService'
-export { exportService } from './ExportService'
-export { notificationService } from './NotificationService'
-export { default as api } from './api' 
+export { authService } from './AuthService';
+export { dataAnalysisService } from './DataAnalysisService';
+export { dataProcessingService } from './DataProcessingService';
+export { DEFAULT_DATASET_CONFIGS, type DatasetType } from './datasetConfigs';
+export { dataImportService } from './DataImportService';
+export { energyService } from './EnergyService';
+export { exportService } from './ExportService';
+export { notificationService } from './NotificationService';
+export { default as api } from './api';


### PR DESCRIPTION
## Summary
- centralize dataset configuration in `datasetConfigs.ts`
- reference dataset configs in `DataProcessingService`
- export dataset helpers in service index
- append missing semicolons

## Testing
- `npm run test` *(fails: vitest not found)*
